### PR TITLE
Light Client Support

### DIFF
--- a/codegen/Cargo.lock
+++ b/codegen/Cargo.lock
@@ -203,9 +203,9 @@ checksum = "ecc7ab41815b3c653ccd2978ec3255c81349336702dfdf62ee6f7069b12a3aae"
 
 [[package]]
 name = "async-trait"
-version = "0.1.73"
+version = "0.1.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
+checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2708,6 +2708,7 @@ dependencies = [
  "subxt-macro",
  "subxt-metadata",
  "thiserror",
+ "tokio-stream",
  "tracing",
 ]
 
@@ -2810,6 +2811,7 @@ name = "subxt_example_codegen"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "bitvec",
  "console_error_panic_hook",
  "heck",

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -24,6 +24,7 @@ web = [
 
 subxt = { version = "0.32.1", default-features = false, features = [
     "jsonrpsee",
+    "unstable-light-client",
 ], target_arch = "wasm32" }
 subxt-metadata = { version = "0.32.1" }
 subxt-codegen = { version = "0.32.1", default-features = false }
@@ -55,6 +56,7 @@ serde-wasm-bindgen = { version = "0.5.0", optional = true }
 console_error_panic_hook = { version = "0.1.7", optional = true }
 peekmore = "1.3.0"
 smallvec = "1.11.1"
+async-trait = "0.1.74"
 
 
 [lib]

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -1,5 +1,4 @@
 #![feature(try_trait_v2)]
-// #![feature(async_fn_in_trait)]
 
 //! This crate exposes a struct [ExampleGenerator] that is capable of generating code examples for calls, constants and storage entries from static metadata.
 //! The generated code can look like this:

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -1,4 +1,5 @@
 #![feature(try_trait_v2)]
+// #![feature(async_fn_in_trait)]
 
 //! This crate exposes a struct [ExampleGenerator] that is capable of generating code examples for calls, constants and storage entries from static metadata.
 //! The generated code can look like this:

--- a/codegen/src/wasm_interface.rs
+++ b/codegen/src/wasm_interface.rs
@@ -10,7 +10,7 @@ use serde::Serialize;
 use subxt::{
     client::{LightClient, LightClientBuilder, OfflineClientT, OnlineClientT},
     ext::{codec::Decode, scale_value},
-    OfflineClient, OnlineClient, SubstrateConfig,
+    OfflineClient, OnlineClient, PolkadotConfig, SubstrateConfig,
 };
 use subxt_metadata::{Metadata, PalletMetadata, RuntimeApiMetadata};
 use syn::Meta;
@@ -40,7 +40,7 @@ extern "C" {
 
 }
 
-type ConfigUsed = SubstrateConfig;
+type ConfigUsed = PolkadotConfig;
 
 #[wasm_bindgen]
 pub struct Client {
@@ -191,14 +191,13 @@ impl Client {
     pub async fn new_light_client(url: &str) -> Result<Client, String> {
         console_error_panic_hook::set_once();
         console_log!("create light client from a chain spec");
-        let client = LightClient::<ConfigUsed>::builder()
-            .bootnodes([
-                "/ip4/127.0.0.1/tcp/30333/p2p/12D3KooWEyoppNCUx8Yx66oV9fJnriXwCcXwDDUA2kj6vnc6iDEp",
-            ])
-            .build_from_url("ws://127.0.0.1:9944")
-            .await
-            .map_err(|e| e.to_string())?;
-
+        let client = LightClientBuilder::<ConfigUsed>::new()
+        .bootnodes(
+            ["/dns/polkadot-connect-0.parity.io/tcp/443/wss/p2p/12D3KooWEPmjoRpDSUuiTjvyNDd8fejZ9eNWH5bE965nyBMDrB4o"]
+        )
+        .build_from_url("wss://rpc.polkadot.io:443")
+        .await.map_err(|e| e.to_string())?;
+        console_log!("light client creation successful");
         Ok(Client::new(ClientKind::LightClient {
             chain_spec_json: "todo!()".into(),
             client,

--- a/codegen/src/wasm_interface.rs
+++ b/codegen/src/wasm_interface.rs
@@ -61,7 +61,7 @@ pub enum ClientKind {
         client: OnlineClient<ConfigUsed>,
     },
     LightClient {
-        chain_spec_json: String,
+        chain_spec: String,
         client: LightClient<ConfigUsed>,
     },
 }
@@ -199,7 +199,7 @@ impl Client {
         .await.map_err(|e| e.to_string())?;
         console_log!("light client creation successful");
         Ok(Client::new(ClientKind::LightClient {
-            chain_spec_json: "todo!()".into(),
+            chain_spec: "todo!()".into(),
             client,
         }))
     }

--- a/codegen/src/wasm_interface.rs
+++ b/codegen/src/wasm_interface.rs
@@ -187,21 +187,18 @@ impl Client {
     }
 
     /// Creates an LightClient from a given chain spec string.
+    ///
+    /// `chain_spec` is expected to be a JSON string that contains the bootnodes and other information.
     #[wasm_bindgen(js_name = "newLightClient")]
-    pub async fn new_light_client(url: &str) -> Result<Client, String> {
+    pub async fn new_light_client(chain_spec: String) -> Result<Client, String> {
         console_error_panic_hook::set_once();
         console_log!("create light client from a chain spec");
         let client = LightClientBuilder::<ConfigUsed>::new()
-        .bootnodes(
-            ["/dns/polkadot-connect-0.parity.io/tcp/443/wss/p2p/12D3KooWEPmjoRpDSUuiTjvyNDd8fejZ9eNWH5bE965nyBMDrB4o"]
-        )
-        .build_from_url("wss://rpc.polkadot.io:443")
-        .await.map_err(|e| e.to_string())?;
+            .build(&chain_spec)
+            .await
+            .map_err(|e| e.to_string())?;
         console_log!("light client creation successful");
-        Ok(Client::new(ClientKind::LightClient {
-            chain_spec: "todo!()".into(),
-            client,
-        }))
+        Ok(Client::new(ClientKind::LightClient { chain_spec, client }))
     }
 
     #[wasm_bindgen(js_name = "metadataContent")]

--- a/codegen/src/wasm_interface/client_object.rs
+++ b/codegen/src/wasm_interface/client_object.rs
@@ -1,0 +1,116 @@
+use async_trait::async_trait;
+use subxt::{
+    client::{LightClient, OfflineClientT},
+    ext::scale_value,
+    Config, Metadata, OfflineClient, OnlineClient,
+};
+
+use anyhow::anyhow;
+
+/// Todo: these implementations could maybe be done by a macro that copies the code 2 or 3 times.
+pub(crate) trait OfflineClientObject<T: Config> {
+    fn metadata(&self) -> Metadata;
+    fn constant_at(
+        &self,
+        pallet_name: &str,
+        constant_name: &str,
+    ) -> anyhow::Result<scale_value::Value<u32>>;
+}
+
+impl<T: Config> OfflineClientObject<T> for OfflineClient<T> {
+    fn metadata(&self) -> Metadata {
+        OfflineClientT::metadata(self)
+    }
+
+    fn constant_at(
+        &self,
+        pallet_name: &str,
+        constant_name: &str,
+    ) -> anyhow::Result<scale_value::Value<u32>> {
+        let address = subxt::constants::dynamic(pallet_name, constant_name);
+        let constants_client = OfflineClientT::constants(self);
+        let decoded_value_thunk = constants_client.at(&address)?;
+        let scale_value = decoded_value_thunk.to_value()?;
+        Ok(scale_value)
+    }
+}
+
+impl<T: Config> OfflineClientObject<T> for OnlineClient<T> {
+    fn metadata(&self) -> Metadata {
+        OfflineClientT::metadata(self)
+    }
+
+    fn constant_at(
+        &self,
+        pallet_name: &str,
+        constant_name: &str,
+    ) -> anyhow::Result<scale_value::Value<u32>> {
+        let address = subxt::constants::dynamic(pallet_name, constant_name);
+        let constants_client = OfflineClientT::constants(self);
+        let decoded_value_thunk = constants_client.at(&address)?;
+        let scale_value = decoded_value_thunk.to_value()?;
+        Ok(scale_value)
+    }
+}
+impl<T: Config> OfflineClientObject<T> for LightClient<T> {
+    fn metadata(&self) -> Metadata {
+        OfflineClientT::metadata(self)
+    }
+
+    fn constant_at(
+        &self,
+        pallet_name: &str,
+        constant_name: &str,
+    ) -> anyhow::Result<scale_value::Value<u32>> {
+        let address = subxt::constants::dynamic(pallet_name, constant_name);
+        let constants_client = OfflineClientT::constants(self);
+        let decoded_value_thunk = constants_client.at(&address)?;
+        let scale_value = decoded_value_thunk.to_value()?;
+        Ok(scale_value)
+    }
+}
+
+#[async_trait]
+pub trait OnlineClientObject<T: Config>: OfflineClientObject<T> {
+    async fn key_less_storage_at(
+        &self,
+        pallet_name: &str,
+        entry_name: &str,
+    ) -> anyhow::Result<scale_value::Value<u32>>;
+}
+
+#[async_trait]
+impl<T: Config> OnlineClientObject<T> for OnlineClient<T> {
+    async fn key_less_storage_at(
+        &self,
+        pallet_name: &str,
+        entry_name: &str,
+    ) -> anyhow::Result<scale_value::Value<u32>> {
+        let storage_client = self.storage().at_latest().await?;
+        let storage_address = subxt::storage::dynamic::<()>(pallet_name, entry_name, vec![]);
+        let value: scale_value::Value<u32> = storage_client
+            .fetch(&storage_address)
+            .await?
+            .ok_or_else(|| anyhow!("No storage value found"))?
+            .to_value()?;
+        Ok(value)
+    }
+}
+
+#[async_trait]
+impl<T: Config> OnlineClientObject<T> for LightClient<T> {
+    async fn key_less_storage_at(
+        &self,
+        pallet_name: &str,
+        entry_name: &str,
+    ) -> anyhow::Result<scale_value::Value<u32>> {
+        let storage_client = self.storage().at_latest().await?;
+        let storage_address = subxt::storage::dynamic::<()>(pallet_name, entry_name, vec![]);
+        let value: scale_value::Value<u32> = storage_client
+            .fetch(&storage_address)
+            .await?
+            .ok_or_else(|| anyhow!("No storage value found"))?
+            .to_value()?;
+        Ok(value)
+    }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,7 +20,6 @@ import { EventsPage } from "./pages/Events";
 import { AppConfig } from "./state/app_config";
 import { RedirectToHome } from "./components/RedirectToHome";
 import { findSideBarItemByPath, setActiveItem } from "./state/sidebar";
-import { ChainSpecService } from "./services/chain_spec_service";
 import { ClientCreationConfig } from "./state/models/client_creation_config";
 
 const App: Component = () => {
@@ -41,7 +40,6 @@ const AppInRouter: Component = () => {
     location.query
   );
   AppConfig.instance.updateWith(clientCreationConfig);
-  ChainSpecService.instance.fetchAndCacheChainSpecs();
 
   // listen to all client side solid router route change events:
   // If the url params indicate a different app config, reload the web app with that config.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,7 +37,10 @@ const AppInRouter: Component = () => {
   // On page load, create a new AppConfig from the URL params.
   // Note: This code is only called ONCE at the start of the application lifecycle.
   const location = useLocation();
-  AppConfig.instance.updateWithParams(location.query);
+  const clientCreationConfig = ClientCreationConfig.tryFromParams(
+    location.query
+  );
+  AppConfig.instance.updateWith(clientCreationConfig);
   ChainSpecService.instance.fetchAndCacheChainSpecs();
 
   // listen to all client side solid router route change events:
@@ -68,7 +71,7 @@ const AppInRouter: Component = () => {
       AppConfig.instance.updateWith(configFromParams);
       if (pathname === "/" || pathname === "") {
         // if already on homepage adjust its UI to the new config:
-        HomePageState.instance.adjustUiToAppConfigInstance();
+        HomePageState.instance.setupUiToMatchAppConfig();
       } else {
         // otherwise navigate to homepage and set redirect hook:
         const redirectUrl = `/?${AppConfig.instance.toParamsString()}`;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,13 +17,11 @@ import { StoragePage } from "./pages/Storage";
 import { ConstantsPage } from "./pages/Constants";
 import { RuntimeApiMethodsPage } from "./pages/RuntimeApiMethods";
 import { EventsPage } from "./pages/Events";
-import {
-  AppConfig,
-  clientKindFromParams,
-  clientKindsEqual,
-} from "./state/app_config";
+import { AppConfig } from "./state/app_config";
 import { RedirectToHome } from "./components/RedirectToHome";
 import { findSideBarItemByPath, setActiveItem } from "./state/sidebar";
+import { ChainSpecService } from "./services/chain_spec_service";
+import { ClientCreationConfig } from "./state/models/client_creation_config";
 
 const App: Component = () => {
   return (
@@ -39,27 +37,35 @@ const AppInRouter: Component = () => {
   // On page load, create a new AppConfig from the URL params.
   // Note: This code is only called ONCE at the start of the application lifecycle.
   const location = useLocation();
-
   AppConfig.instance.updateWithParams(location.query);
+  ChainSpecService.instance.fetchAndCacheChainSpecs();
 
   // listen to all client side solid router route change events:
   // If the url params indicate a different app config, reload the web app with that config.
   createEffect(() => {
     const pathname = location.pathname;
 
-    if (pathname == "/" && HomePageState.instance.generating) {
+    if (pathname == "/" && HomePageState.instance.is_loading) {
       // we do not want anything here to trigger if the home page is currently generating some client connection.
       return;
     }
 
+    // set the active sidebar item according to the location:
     const newItem = findSideBarItemByPath(pathname);
     if (newItem) {
       setActiveItem(newItem);
     }
 
-    const paramsClientKind = clientKindFromParams(location.query);
-    if (!clientKindsEqual(paramsClientKind, AppConfig.instance.clientKind)) {
-      AppConfig.instance.updateWith(paramsClientKind);
+    // extract a new client creation config from the url params:
+    const configFromParams = ClientCreationConfig.tryFromParams(location.query);
+    if (
+      !ClientCreationConfig.equals(
+        configFromParams,
+        AppConfig.instance.clientCreationConfig
+      )
+    ) {
+      // if it differs from the currently used config, update the app config and reload the app:
+      AppConfig.instance.updateWith(configFromParams);
       if (pathname === "/" || pathname === "") {
         // if already on homepage adjust its UI to the new config:
         HomePageState.instance.adjustUiToAppConfigInstance();

--- a/src/components/ChainSpecPresetSelection.tsx
+++ b/src/components/ChainSpecPresetSelection.tsx
@@ -1,0 +1,55 @@
+import { Accessor, JSX, Match, Switch } from "solid-js";
+import { ChainSpec, ChainSpecService } from "../services/chain_spec_service";
+
+export const ChainSpecPresetSelection = (props: {
+  onChainSpecPresetSelected: (chainSpec: ChainSpec) => void;
+  selectedSpecName: Accessor<string | undefined>;
+}): JSX.Element => {
+  const chainSpecs = ChainSpecService.instance.chainSpecs;
+  return (
+    <Switch>
+      <Match when={chainSpecs().tag === "loading"}>
+        <div class="text-center w-full mb-4">Loading...</div>
+      </Match>
+      <Match when={chainSpecs().tag === "success"}>
+        <div class="flex align-middle w-full justify-around">
+          {(chainSpecs() as { tag: "success"; specs: ChainSpec[] }).specs.map(
+            (e) => (
+              <div class="flex align-middle">
+                <input
+                  //   class="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600"
+                  class={`appearance-none w-7 h-7 rounded-full cursor-pointer border-solid border-2 ${
+                    props.selectedSpecName() == e.name
+                      ? "bg-pink-500 border-white"
+                      : "bg-zinc-dark border-gray-500"
+                  }`}
+                  //   style={{ border: "2px solid #F472B6" }}
+                  type="radio"
+                  id={e.name}
+                  name="chainspec_preset"
+                  value={e.name}
+                  onClick={() => {
+                    props.onChainSpecPresetSelected(e);
+                  }}
+                />
+                <label
+                  class={`pl-2 font-bold cursor-pointer ${
+                    props.selectedSpecName() == e.name ? "text-white" : ""
+                  }`}
+                  for={e.name}
+                >
+                  {e.name}
+                </label>
+              </div>
+            )
+          )}
+        </div>
+      </Match>
+      <Match when={chainSpecs().tag === "error"}>
+        <div class="text-center w-full text-red-400 mb-4">
+          Error: {(chainSpecs() as { tag: "error"; error: string }).error}
+        </div>
+      </Match>
+    </Switch>
+  );
+};

--- a/src/components/ChainSpecPresetSelection.tsx
+++ b/src/components/ChainSpecPresetSelection.tsx
@@ -9,7 +9,11 @@ export const ChainSpecPresetSelection = (props: {
   return (
     <Switch>
       <Match when={chainSpecs().tag === "loading"}>
-        <div class="text-center w-full mb-4">Loading...</div>
+        <div class="text-center w-full mb-4">
+          {" "}
+          <i class="fa fa-spinner animate-spin"></i> Loading chain spec
+          presets...
+        </div>
       </Match>
       <Match when={chainSpecs().tag === "success"}>
         <div class="flex align-middle w-full justify-around">

--- a/src/components/ChainSpecPresetSelection.tsx
+++ b/src/components/ChainSpecPresetSelection.tsx
@@ -21,13 +21,11 @@ export const ChainSpecPresetSelection = (props: {
             (e) => (
               <div class="flex align-middle">
                 <input
-                  //   class="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600"
                   class={`appearance-none w-7 h-7 rounded-full cursor-pointer border-solid border-2 ${
                     props.selectedSpecName() == e.name
                       ? "bg-pink-500 border-white"
                       : "bg-zinc-dark border-gray-500"
                   }`}
-                  //   style={{ border: "2px solid #F472B6" }}
                   type="radio"
                   id={e.name}
                   name="chainspec_preset"
@@ -51,7 +49,8 @@ export const ChainSpecPresetSelection = (props: {
       </Match>
       <Match when={chainSpecs().tag === "error"}>
         <div class="text-center w-full text-red-400 mb-4">
-          Error: {(chainSpecs() as { tag: "error"; error: string }).error}
+          Error while loading chain spec presets:{" "}
+          {(chainSpecs() as { tag: "error"; error: string }).error}
         </div>
       </Match>
     </Switch>

--- a/src/components/ChainSpecPresetSelection.tsx
+++ b/src/components/ChainSpecPresetSelection.tsx
@@ -1,11 +1,28 @@
-import { Accessor, JSX, Match, Switch } from "solid-js";
+import { Accessor, JSX, Match, Switch, createSignal, onMount } from "solid-js";
 import { ChainSpec, ChainSpecService } from "../services/chain_spec_service";
+
+type ChainSpecsFetchingState =
+  | { tag: "success"; specs: ChainSpec[] }
+  | { tag: "loading" }
+  | { tag: "error"; error: string };
 
 export const ChainSpecPresetSelection = (props: {
   onChainSpecPresetSelected: (chainSpec: ChainSpec) => void;
   selectedSpecName: Accessor<string | undefined>;
 }): JSX.Element => {
-  const chainSpecs = ChainSpecService.instance.chainSpecs;
+  const [chainSpecs, setChainSpecs] = createSignal<ChainSpecsFetchingState>({
+    tag: "loading",
+  });
+
+  onMount(async () => {
+    try {
+      const specs = await ChainSpecService.instance.fetchChainSpecs();
+      setChainSpecs({ tag: "success", specs });
+    } catch (ex: any) {
+      setChainSpecs({ tag: "error", error: ex.toString() });
+    }
+  });
+
   return (
     <Switch>
       <Match when={chainSpecs().tag === "loading"}>

--- a/src/components/CodeTabLayout.tsx
+++ b/src/components/CodeTabLayout.tsx
@@ -16,7 +16,7 @@ export const CodeTabLayout: Component<Props> = (props: Props) => {
         icon: "fa-cube",
         onClick: () => setTab("static"),
       },
-      content: <Code code={props.staticCode}></Code>,
+      component: () => <Code code={props.staticCode}></Code>,
     },
     {
       tab: {
@@ -25,7 +25,7 @@ export const CodeTabLayout: Component<Props> = (props: Props) => {
         icon: "fa-bomb",
         onClick: () => setTab("dynamic"),
       },
-      content: <Code code={props.dynamicCode}></Code>,
+      component: () => <Code code={props.dynamicCode}></Code>,
     },
   ];
 

--- a/src/components/FileUploadArea.tsx
+++ b/src/components/FileUploadArea.tsx
@@ -1,31 +1,31 @@
-import { Component } from "solid-js";
+import { Component, createSignal } from "solid-js";
 interface Props {
   description: string;
-  isDragging: boolean;
   fileName: string | undefined;
-  setDragging: (dragging: boolean) => void;
   onDropOrUpload: (fileList: FileList | undefined) => void;
 }
 export const FileUploadArea: Component<Props> = (props: Props) => {
+  const [isDragging, setDragging] = createSignal<boolean>(false);
+
   let fileInputRef: HTMLInputElement | undefined;
 
   return (
     <div
       class={`w-full h-60 border-dashed border-2 rounded-md border-gray-500 flex justify-center bg-zinc-dark ${
-        props.isDragging ? "neon-inner-shadow" : ""
+        isDragging() ? "neon-inner-shadow" : ""
       }`}
       onDragEnter={(e) => {
-        props.setDragging(true);
+        setDragging(true);
         e.preventDefault();
         e.stopPropagation();
       }}
       onDragLeave={(e) => {
-        props.setDragging(false);
+        setDragging(false);
         e.preventDefault();
         e.stopPropagation();
       }}
       onDragExit={(e) => {
-        props.setDragging(false);
+        setDragging(false);
         e.preventDefault();
         e.stopPropagation();
       }}
@@ -34,7 +34,7 @@ export const FileUploadArea: Component<Props> = (props: Props) => {
         e.stopPropagation();
       }}
       onDrop={(e) => {
-        props.setDragging(false);
+        setDragging(false);
         e.preventDefault();
         e.stopPropagation();
         const files = e.dataTransfer?.files;

--- a/src/components/RedirectToHome.tsx
+++ b/src/components/RedirectToHome.tsx
@@ -1,6 +1,6 @@
 import { Navigate, useLocation } from "@solidjs/router";
 import {
-  clientKindFromParams,
+  clientCreationConfigFromParams,
   clientKindToParams,
   paramsToString,
 } from "../state/app_config";
@@ -9,7 +9,7 @@ import { HomePageState } from "../pages/Home";
 
 export function RedirectToHome(): JSX.Element {
   const location = useLocation();
-  const clientKind = clientKindFromParams(location.query);
+  const clientKind = clientCreationConfigFromParams(location.query);
   const params = clientKindToParams(clientKind);
   const redirectUrl = `/?${paramsToString(params)}`;
   HomePageState.instance.setRedirectPath(location.pathname);

--- a/src/components/RedirectToHome.tsx
+++ b/src/components/RedirectToHome.tsx
@@ -1,16 +1,15 @@
 import { Navigate, useLocation } from "@solidjs/router";
-import {
-  clientCreationConfigFromParams,
-  clientKindToParams,
-  paramsToString,
-} from "../state/app_config";
 import { JSX } from "solid-js";
 import { HomePageState } from "../pages/Home";
+import { ClientCreationConfig } from "../state/models/client_creation_config";
+import { paramsToString } from "../utils";
 
 export function RedirectToHome(): JSX.Element {
   const location = useLocation();
-  const clientKind = clientCreationConfigFromParams(location.query);
-  const params = clientKindToParams(clientKind);
+  const clientCreationConfig = ClientCreationConfig.tryFromParams(
+    location.query
+  );
+  const params = clientCreationConfig?.intoParams() ?? {};
   const redirectUrl = `/?${paramsToString(params)}`;
   HomePageState.instance.setRedirectPath(location.pathname);
   return <Navigate href={redirectUrl} />;

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -98,6 +98,8 @@ function metadataSourceSpan(ck: ClientKind): JSX.Element {
           <span class="text-pink-500">{ck.file.name}</span>
         </span>
       );
+    case "lightclient":
+      return <span>{"Connected to LightClient"}</span>;
   }
 }
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { Component, For, JSX } from "solid-js";
-import { ClientKind, client } from "../state/client";
+import { client } from "../state/client";
 import {
   HOME_ITEM,
   SidebarItem,
@@ -7,6 +7,7 @@ import {
   sidebarItems,
 } from "../state/sidebar";
 import { ConfigAwareLink } from "./ConfigAwareLink";
+import { ClientCreationData } from "../state/models/client_creation_data";
 
 export const Sidebar: Component = () => {
   return (
@@ -26,7 +27,7 @@ export const Sidebar: Component = () => {
           </li>
           {client() && (
             <li class="part-title leading-6 pt-6 pb-3">
-              {metadataSourceSpan(client()!.creationData!)}
+              {clientConnectionSpan(client()!.creationData)}
             </li>
           )}
 
@@ -82,20 +83,24 @@ function SideBarItem(item: SidebarItem): JSX.Element {
   );
 }
 
-function metadataSourceSpan(ck: ClientKind): JSX.Element {
-  switch (ck.tag) {
+function clientConnectionSpan(
+  clientCreationData: ClientCreationData
+): JSX.Element {
+  switch (clientCreationData.deref.tag) {
     case "url":
       return (
         <span>
           {"Connected to: "}
-          <span class="text-pink-500">{ck.url}</span>
+          <span class="text-pink-500">{clientCreationData.deref.url}</span>
         </span>
       );
     case "file":
       return (
         <span>
           {"Metadata from: "}
-          <span class="text-pink-500">{ck.file.name}</span>
+          <span class="text-pink-500">
+            {clientCreationData.deref.file.name}
+          </span>
         </span>
       );
     case "lightclient":

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -26,7 +26,7 @@ export const Sidebar: Component = () => {
           </li>
           {client() && (
             <li class="part-title leading-6 pt-6 pb-3">
-              {metadataSourceSpan(client()!.clientKindInCreation!)}
+              {metadataSourceSpan(client()!.creationData!)}
             </li>
           )}
 

--- a/src/components/TabLayout.tsx
+++ b/src/components/TabLayout.tsx
@@ -3,7 +3,7 @@ import { Tab, Props as TabProps } from "./Tab";
 
 export interface TabWithContent {
   tab: TabProps;
-  content: JSX.Element;
+  component: () => JSX.Element;
 }
 
 export interface Props {
@@ -21,7 +21,7 @@ export const TabLayout = (props: Props): JSX.Element => {
         ))}
       </div>
       <div class={props.contentContainerClass}>
-        {props.tabs.map((c) => c.tab.active() && c.content)}
+        {props.tabs.map((c) => c.tab.active() && c.component())}
       </div>
     </>
   );

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,1 +1,6 @@
+import { ClientCreationDataTag } from "./state/models/client_creation_data";
+
 export const DEFAULT_WS_URL = "wss://rpc.polkadot.io";
+export const DEFAULT_HOME_PAGE_TAB: ClientCreationDataTag = "lightclient";
+export const SUBSTRATE_CONNECT_CHAIN_SPECS_GITHUB_URL =
+  "https://api.github.com/repos/paritytech/substrate-connect/contents/packages/connect/src/connector/specs";

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,6 @@
 import { ClientCreationDataTag } from "./state/models/client_creation_data";
 
 export const DEFAULT_WS_URL = "wss://rpc.polkadot.io";
-export const DEFAULT_HOME_PAGE_TAB: ClientCreationDataTag = "lightclient";
+export const DEFAULT_HOME_PAGE_TAB: ClientCreationDataTag = "url";
 export const SUBSTRATE_CONNECT_CHAIN_SPECS_GITHUB_URL =
   "https://api.github.com/repos/paritytech/substrate-connect/contents/packages/connect/src/connector/specs";

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -202,9 +202,8 @@ export class HomePageState {
   // used on:
   // - page load
   // - when the url params change and the AppConfig changes as a result.
-  async adjustUiToAppConfigInstance() {
+  async setupUiToMatchAppConfig() {
     const creationConfig = AppConfig.instance.clientCreationConfig;
-    console.log("adjustUiToAppConfigInstance with", creationConfig);
     if (
       creationConfig != undefined &&
       !ClientCreationConfig.equals(
@@ -238,7 +237,7 @@ export const HomePage: Component = () => {
   const setSearchParams = useSearchParams()[1];
   const navigate = useNavigate();
   state.infuseNavigationFns(setSearchParams, navigate);
-  state.adjustUiToAppConfigInstance();
+  state.setupUiToMatchAppConfig();
 
   // a signal that is true if the generate button is clickable.
   const generateButtonClickable = (): boolean => {

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -266,7 +266,7 @@ export const HomePage: Component = () => {
   const FileTabContent = () => (
     <FileUploadArea
       fileName={state.file()?.name}
-      description={`Drag Metadata (.scale) file here, or click "Upload"`}
+      description={`Drag metadata file (.scale) here, or click "Upload"`}
       onDropOrUpload={(files) => {
         if (files === undefined) {
           state.setError("Something went wrong with the file upload.");
@@ -290,7 +290,7 @@ export const HomePage: Component = () => {
             ? state.lightClientChainSpec()?.name
             : undefined
         }
-        description={`Drag ChainSpec (.json) file here, or click "Upload"`}
+        description={`Drag chain spec file (.json) here, or click "Upload"`}
         onDropOrUpload={async (files) => {
           if (files === undefined) {
             state.setError("Something went wrong with the file upload.");

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -104,7 +104,7 @@ export class HomePageState {
     return this.loadingState() === "loading";
   }
 
-  // takes the state of the ui elements and translates that into a clientKind that can be used to create a client.
+  // takes the state of the ui elements and translates that into `ClientCreationData` that can be used to create a client.
   clientCreationDataFromTab = (): ClientCreationData | undefined => {
     if (this.error() !== undefined) {
       return undefined;
@@ -131,10 +131,6 @@ export class HomePageState {
           tag: "lightclient",
           chain_spec: spec,
         });
-        // const lightclient = this.lightClientChainSpec();
-        // // let chain_spec = this.lightClientChainSpec();
-        // throw "todo!()";
-        // return chain_spec && { tag: "lightclient", chain_spec };
       }
     }
   };
@@ -375,7 +371,6 @@ export const HomePage: Component = () => {
           class={`btn ${generateButtonClickable() ? "" : "disabled"}`}
           disabled={!generateButtonClickable()}
           onClick={() => {
-            // assumption: Button is only clickable if homeScreenClientKind() is a valid value.
             state.generateAndUpdateAppConfig();
           }}
         >

--- a/src/services/chain_spec_service.ts
+++ b/src/services/chain_spec_service.ts
@@ -1,7 +1,5 @@
 import { Accessor, Setter, createSignal } from "solid-js";
-
-const SUBSTRATE_CONNECT_CHAIN_SPECS_GITHUB_URL =
-  "https://api.github.com/repos/paritytech/substrate-connect/contents/packages/connect/src/connector/specs";
+import { SUBSTRATE_CONNECT_CHAIN_SPECS_GITHUB_URL } from "../constants";
 
 export type ChainSpec = {
   bootNodes: string[];
@@ -9,7 +7,7 @@ export type ChainSpec = {
   id: string;
 } & Record<string, unknown>;
 
-type ChainSpecsFetchingState =
+export type ChainSpecsFetchingState =
   | { tag: "success"; specs: ChainSpec[] }
   | { tag: "loading" }
   | { tag: "error"; error: string };
@@ -35,6 +33,7 @@ export class ChainSpecService {
   }
 
   async fetchAndCacheChainSpecs(): Promise<void> {
+    console.log("ChainSpecService: start fetching chain specs...");
     this.#setChainSpecs({ tag: "loading" });
     try {
       const res = await fetch(SUBSTRATE_CONNECT_CHAIN_SPECS_GITHUB_URL);
@@ -50,9 +49,11 @@ export class ChainSpecService {
         specs.push(spec as ChainSpec);
       }
 
+      console.log("ChainSpecService: fetching success ");
       this.#handleOnLoadCallbacks(specs);
       this.#setChainSpecs({ tag: "success", specs });
     } catch (ex: any) {
+      console.error("ChainSpecService: error: ", ex);
       this.#setChainSpecs({
         tag: "error",
         error: ex.toString(),

--- a/src/services/chain_spec_service.ts
+++ b/src/services/chain_spec_service.ts
@@ -1,0 +1,26 @@
+const SUBSTRATE_CONNECT_CHAIN_SPECS_GITHUB_URL =
+  "https://api.github.com/repos/paritytech/substrate-connect/contents/packages/connect/src/connector/specs";
+
+export type ChainSpec = {
+  bootNodes: string[];
+  name: string;
+  id: string;
+} & Record<string, unknown>;
+
+export class ChainSpecService {
+  static async fetchChainSpecs(): Promise<ChainSpec[]> {
+    const res = await fetch(SUBSTRATE_CONNECT_CHAIN_SPECS_GITHUB_URL);
+    const json: any = await res.json();
+
+    const specs: ChainSpec[] = [];
+    for (const fileEntry of json) {
+      if (!fileEntry.name.endsWith(".json")) {
+        continue;
+      }
+      const res = await fetch(fileEntry.download_url);
+      const spec: unknown = await res.json();
+      specs.push(spec as ChainSpec);
+    }
+    return specs;
+  }
+}

--- a/src/services/chain_spec_service.ts
+++ b/src/services/chain_spec_service.ts
@@ -1,4 +1,3 @@
-import { Accessor, Setter, createSignal } from "solid-js";
 import { SUBSTRATE_CONNECT_CHAIN_SPECS_GITHUB_URL } from "../constants";
 
 export type ChainSpec = {
@@ -7,15 +6,7 @@ export type ChainSpec = {
   id: string;
 } & Record<string, unknown>;
 
-export type ChainSpecsFetchingState =
-  | { tag: "success"; specs: ChainSpec[] }
-  | { tag: "loading" }
-  | { tag: "error"; error: string };
-
 export class ChainSpecService {
-  chainSpecs: Accessor<ChainSpecsFetchingState>;
-  #setChainSpecs: Setter<ChainSpecsFetchingState>;
-
   static #instance: ChainSpecService;
   static get instance(): ChainSpecService {
     if (ChainSpecService.#instance === undefined) {
@@ -24,88 +15,41 @@ export class ChainSpecService {
     return ChainSpecService.#instance;
   }
 
-  constructor() {
-    const [chainSpecs, setChainSpecs] = createSignal<ChainSpecsFetchingState>({
-      tag: "loading",
-    });
-    this.chainSpecs = chainSpecs;
-    this.#setChainSpecs = setChainSpecs;
-  }
+  constructor() {}
 
-  async fetchAndCacheChainSpecs(): Promise<void> {
-    console.log("ChainSpecService: start fetching chain specs...");
-    this.#setChainSpecs({ tag: "loading" });
-    try {
-      const res = await fetch(SUBSTRATE_CONNECT_CHAIN_SPECS_GITHUB_URL);
-      const json: any = await res.json();
+  async fetchChainSpecs(): Promise<ChainSpec[]> {
+    let loading: Promise<ChainSpec[]> | undefined = undefined;
 
-      const specs: ChainSpec[] = [];
-      for (const fileEntry of json) {
-        if (!fileEntry.name.endsWith(".json")) {
-          continue;
-        }
-        const res = await fetch(fileEntry.download_url);
-        const spec: unknown = await res.json();
-        specs.push(spec as ChainSpec);
-      }
-
-      console.log("ChainSpecService: fetching successful!", specs);
-      this.#handleOnLoadCallbacks(specs);
-      this.#setChainSpecs({ tag: "success", specs });
-    } catch (ex: any) {
-      console.error("ChainSpecService: fetching error!", ex);
-      this.#setChainSpecs({
-        tag: "error",
-        error: ex.toString(),
+    if (!loading) {
+      loading = fetchChainSpecs().catch((e) => {
+        loading = undefined;
+        throw e;
       });
     }
+    return loading;
   }
 
-  #on_load_call_backs: ChainSpecResolver[] = [];
-  #handleOnLoadCallbacks(specs: ChainSpec[]) {
-    for (const [chain_name, resolve, reject] of this.#on_load_call_backs) {
-      const spec = specs.find((spec) => spec.name === chain_name);
-      if (spec) {
-        resolve(spec);
-      } else {
-        reject(
-          new Error(
-            `Chain spec with name ${chain_name} not found in loaded presets`
-          )
-        );
-      }
-    }
-    this.#on_load_call_backs = [];
-  }
-
-  loadChainSpecForChainName(chain_name: string): Promise<ChainSpec> {
-    const chainSpecs = this.chainSpecs();
-    switch (chainSpecs.tag) {
-      case "success": {
-        const spec = chainSpecs.specs.find((spec) => spec.name === chain_name);
-        if (spec) {
-          return Promise.resolve(spec);
-        } else {
-          return Promise.reject(
-            new Error(
-              `Chain spec with name ${chain_name} not found in loaded presets`
-            )
-          );
-        }
-      }
-      case "loading": {
-        return new Promise((resolve, reject) => {
-          this.#on_load_call_backs.push([chain_name, resolve, reject]);
-        });
-      }
-      case "error":
-        return Promise.reject(new Error(chainSpecs.error));
-    }
+  async fetchChainSpecForChainName(
+    chain_name: string
+  ): Promise<ChainSpec | undefined> {
+    const specs = await fetchChainSpecs();
+    const spec = specs.find((spec) => spec.name === chain_name);
+    return spec;
   }
 }
 
-type ChainSpecResolver = [
-  string,
-  (value: ChainSpec | PromiseLike<ChainSpec>) => void,
-  (reason?: any) => void
-];
+async function fetchChainSpecs(): Promise<ChainSpec[]> {
+  const res = await fetch(SUBSTRATE_CONNECT_CHAIN_SPECS_GITHUB_URL);
+  const json: any = await res.json();
+  const specs: ChainSpec[] = [];
+  for (const fileEntry of json) {
+    if (!fileEntry.name.endsWith(".json")) {
+      continue;
+    }
+    const res = await fetch(fileEntry.download_url);
+    const spec: unknown = await res.json();
+    specs.push(spec as ChainSpec);
+  }
+  console.log("ChainSpecService: fetching successful!", specs);
+  return specs;
+}

--- a/src/services/chain_spec_service.ts
+++ b/src/services/chain_spec_service.ts
@@ -49,11 +49,11 @@ export class ChainSpecService {
         specs.push(spec as ChainSpec);
       }
 
-      console.log("ChainSpecService: fetching success ");
+      console.log("ChainSpecService: fetching successful!", specs);
       this.#handleOnLoadCallbacks(specs);
       this.#setChainSpecs({ tag: "success", specs });
     } catch (ex: any) {
-      console.error("ChainSpecService: error: ", ex);
+      console.error("ChainSpecService: fetching error!", ex);
       this.#setChainSpecs({
         tag: "error",
         error: ex.toString(),

--- a/src/state/app_config.ts
+++ b/src/state/app_config.ts
@@ -23,7 +23,8 @@ export class AppConfig {
 
   updateWith(clientCreationConfig: ClientCreationConfig | undefined) {
     this.clientCreationConfig = clientCreationConfig;
-    this.#setAppConfigParamString(this.toParamsString());
+    const paramsString = this.toParamsString();
+    this.#setAppConfigParamString(paramsString);
   }
 
   constructor(clientCreationConfig: ClientCreationConfig | undefined) {
@@ -45,15 +46,6 @@ export class AppConfig {
 
   toParamsString(): string {
     return paramsToString(this.toParams());
-  }
-
-  updateWithParams(params: Record<string, string>) {
-    this.clientCreationConfig = ClientCreationConfig.tryFromParams(params);
-    console.log(
-      "AppConfig: updated with params: ",
-      params,
-      this.clientCreationConfig
-    );
   }
 
   equals(other: AppConfig): boolean {

--- a/src/state/app_config.ts
+++ b/src/state/app_config.ts
@@ -103,5 +103,7 @@ export function clientKindsEqual(
       return c1.url === (c2 as { tag: "url"; url: string }).url;
     case "file":
       return true;
+    case "lightclient":
+      return true;
   }
 }

--- a/src/state/app_config.ts
+++ b/src/state/app_config.ts
@@ -1,11 +1,13 @@
 import { Accessor, Setter, createSignal } from "solid-js";
-import { ClientKind } from "./client";
+import { ClientCreationConfig } from "./models/client_creation_config";
+import { paramsToString } from "../utils";
 
 /**
  * A config object that is created at the start of the application lifecycle and can be updated at runtime.
  */
 export class AppConfig {
-  clientKind: ClientKind | undefined;
+  clientCreationConfig: ClientCreationConfig | undefined;
+  lastSuccessFullClientCreationConfig: ClientCreationConfig | undefined;
 
   // Signal used mainly in href of links.
   #setAppConfigParamString: Setter<string>;
@@ -19,13 +21,13 @@ export class AppConfig {
     return AppConfig.#instance;
   }
 
-  updateWith(clientKind: ClientKind | undefined) {
-    this.clientKind = clientKind;
+  updateWith(clientCreationConfig: ClientCreationConfig | undefined) {
+    this.clientCreationConfig = clientCreationConfig;
     this.#setAppConfigParamString(this.toParamsString());
   }
 
-  constructor(clientKind: ClientKind | undefined) {
-    this.clientKind = clientKind;
+  constructor(clientCreationConfig: ClientCreationConfig | undefined) {
+    this.clientCreationConfig = clientCreationConfig;
     const [appConfigParamString, setAppConfigParamString] =
       createSignal<string>(this.toParamsString());
     this.appConfigParamString = appConfigParamString;
@@ -38,8 +40,7 @@ export class AppConfig {
   }
 
   toParams(): Record<string, string> {
-    const params: Record<string, string> = clientKindToParams(this.clientKind);
-    return params;
+    return this.clientCreationConfig?.intoParams() ?? {};
   }
 
   toParamsString(): string {
@@ -47,63 +48,13 @@ export class AppConfig {
   }
 
   updateWithParams(params: Record<string, string>) {
-    this.clientKind = clientKindFromParams(params);
+    this.clientCreationConfig = ClientCreationConfig.tryFromParams(params);
   }
 
   equals(other: AppConfig): boolean {
-    return clientKindsEqual(this.clientKind, other.clientKind);
-  }
-}
-
-export function clientKindFromParams(
-  params: Record<string, string>
-): ClientKind | undefined {
-  const url = params["url"];
-  if (url) {
-    return {
-      tag: "url",
-      url: decodeURI(url),
-    };
-  }
-  return undefined;
-}
-
-export function clientKindToParams(
-  clientKind: ClientKind | undefined
-): Record<string, string> {
-  const params: Record<string, string> = {};
-  if (clientKind?.tag === "url") {
-    params["url"] = clientKind.url;
-  }
-  return params;
-}
-
-export function paramsToString(params: Record<string, string>): string {
-  return new URLSearchParams(Object.entries(params)).toString();
-}
-
-export function clientKindsEqual(
-  c1: ClientKind | undefined,
-  c2: ClientKind | undefined
-): boolean {
-  if (c1 === c2) {
-    return true;
-  }
-
-  if (c1 === undefined || c2 === undefined) {
-    return false;
-  }
-
-  if (c1.tag !== c2.tag) {
-    return false;
-  }
-
-  switch (c1.tag) {
-    case "url":
-      return c1.url === (c2 as { tag: "url"; url: string }).url;
-    case "file":
-      return true;
-    case "lightclient":
-      return true;
+    return ClientCreationConfig.equals(
+      this.clientCreationConfig,
+      other.clientCreationConfig
+    );
   }
 }

--- a/src/state/app_config.ts
+++ b/src/state/app_config.ts
@@ -49,6 +49,11 @@ export class AppConfig {
 
   updateWithParams(params: Record<string, string>) {
     this.clientCreationConfig = ClientCreationConfig.tryFromParams(params);
+    console.log(
+      "AppConfig: updated with params: ",
+      params,
+      this.clientCreationConfig
+    );
   }
 
   equals(other: AppConfig): boolean {

--- a/src/state/client.ts
+++ b/src/state/client.ts
@@ -30,11 +30,11 @@ export class Client {
     let client: WASMClient;
     switch (clientKind.tag) {
       case "url":
-        client = await WASMClient.fromUrl(clientKind.url);
+        client = await WASMClient.newOnline(clientKind.url);
         break;
       case "file": {
         const bytes = await readFileAsBytes(clientKind.file);
-        client = WASMClient.fromBytes(clientKind.file.name, bytes);
+        client = WASMClient.newOffline(clientKind.file.name, bytes);
         break;
       }
     }

--- a/src/state/client.ts
+++ b/src/state/client.ts
@@ -37,7 +37,7 @@ export class Client {
         } else {
           // convert the JS Object into a json string:
           jsonText = JSON.stringify(clientData.chain_spec);
-        } // todo!();
+        }
         client = await WASMClient.newLightClient(jsonText);
         break;
       }

--- a/src/state/client.ts
+++ b/src/state/client.ts
@@ -30,9 +30,15 @@ export class Client {
         break;
       }
       case "lightclient": {
-        // const chain_spec_text = await clientKind.chain_spec.text();
-        // needle
-        client = await WASMClient.newLightClient("todo!()"); // todo!();
+        let jsonText: string;
+        if (clientData.chain_spec instanceof File) {
+          // read the file as text:
+          jsonText = await clientData.chain_spec.text();
+        } else {
+          // convert the JS Object into a json string:
+          jsonText = JSON.stringify(clientData.chain_spec);
+        } // todo!();
+        client = await WASMClient.newLightClient(jsonText);
         break;
       }
     }

--- a/src/state/client.ts
+++ b/src/state/client.ts
@@ -11,6 +11,10 @@ export type ClientKind =
   | {
       tag: "file";
       file: File;
+    }
+  | {
+      tag: "lightclient";
+      chain_spec: File;
     };
 
 export const [client, setClient] = createSignal<Client | undefined>(undefined);
@@ -35,6 +39,11 @@ export class Client {
       case "file": {
         const bytes = await readFileAsBytes(clientKind.file);
         client = WASMClient.newOffline(clientKind.file.name, bytes);
+        break;
+      }
+      case "lightclient": {
+        // const chain_spec_text = await clientKind.chain_spec.text();
+        client = await WASMClient.newLightClient("todo!()");
         break;
       }
     }

--- a/src/state/models/client_creation_config.ts
+++ b/src/state/models/client_creation_config.ts
@@ -22,6 +22,13 @@ export class ClientCreationConfig {
         url: decodeURI(url),
       });
     }
+    const lightclient = params["lightclient"];
+    if (lightclient) {
+      return new ClientCreationConfig({
+        tag: "lightclient",
+        chain_name: decodeURI(lightclient),
+      });
+    }
     return undefined;
   }
 
@@ -51,7 +58,6 @@ export class ClientCreationConfig {
           );
         return new ClientCreationData({
           tag: "lightclient",
-          is_preset: true,
           chain_spec,
         });
       }

--- a/src/state/models/client_creation_config.ts
+++ b/src/state/models/client_creation_config.ts
@@ -1,0 +1,105 @@
+import { ChainSpecService } from "../../services/chain_spec_service";
+import { ClientCreationData } from "./client_creation_data";
+
+export class ClientCreationConfig {
+  #inner: TClientCreationConfig;
+
+  get deref(): TClientCreationConfig {
+    return this.#inner;
+  }
+
+  constructor(inner: TClientCreationConfig) {
+    this.#inner = inner;
+  }
+
+  static tryFromParams(
+    params: Record<string, string>
+  ): ClientCreationConfig | undefined {
+    const url = params["url"];
+    if (url) {
+      return new ClientCreationConfig({
+        tag: "url",
+        url: decodeURI(url),
+      });
+    }
+    return undefined;
+  }
+
+  intoParams(): Record<string, string> {
+    const params: Record<string, string> = {};
+
+    switch (this.#inner?.tag) {
+      case "url":
+        params["url"] = this.#inner.url;
+        break;
+      case "lightclient":
+        params["lightclient"] = this.#inner.chain_name;
+        break;
+    }
+
+    return params;
+  }
+
+  async intoClientCreationData(): Promise<ClientCreationData> {
+    switch (this.#inner?.tag) {
+      case "url":
+        return new ClientCreationData({ tag: "url", url: this.#inner.url });
+      case "lightclient": {
+        const chain_spec =
+          await ChainSpecService.instance.loadChainSpecForChainName(
+            this.#inner.chain_name
+          );
+        return new ClientCreationData({
+          tag: "lightclient",
+          is_preset: true,
+          chain_spec,
+        });
+      }
+    }
+  }
+
+  equals(other: ClientCreationConfig | undefined): boolean {
+    return ClientCreationConfig.equals(this, other);
+  }
+
+  static equals(
+    a: ClientCreationConfig | undefined,
+    b: ClientCreationConfig | undefined
+  ): boolean {
+    if (a === b) {
+      return true;
+    }
+
+    if (a === undefined || b === undefined) {
+      return false;
+    }
+
+    if (a.#inner.tag !== b.#inner.tag) {
+      return false;
+    }
+
+    switch (a.#inner.tag) {
+      case "url":
+        return a.#inner.url === (b.#inner as OnlineClientCreationConfig).url;
+      case "lightclient":
+        return (
+          a.#inner.chain_name ===
+          (b.#inner as LightClientCreationConfig).chain_name
+        );
+    }
+  }
+}
+
+export type TClientCreationConfig =
+  | OnlineClientCreationConfig
+  | LightClientCreationConfig;
+
+type OnlineClientCreationConfig = {
+  tag: "url";
+  url: string;
+};
+
+type LightClientCreationConfig = {
+  tag: "lightclient";
+  chain_name: string;
+};

--- a/src/state/models/client_creation_config.ts
+++ b/src/state/models/client_creation_config.ts
@@ -53,9 +53,12 @@ export class ClientCreationConfig {
         return new ClientCreationData({ tag: "url", url: this.#inner.url });
       case "lightclient": {
         const chain_spec =
-          await ChainSpecService.instance.loadChainSpecForChainName(
+          await ChainSpecService.instance.fetchChainSpecForChainName(
             this.#inner.chain_name
           );
+        if (chain_spec == undefined) {
+          throw `Could not load chain spec for chain ${this.#inner.chain_name}`;
+        }
         return new ClientCreationData({
           tag: "lightclient",
           chain_spec,

--- a/src/state/models/client_creation_data.ts
+++ b/src/state/models/client_creation_data.ts
@@ -24,13 +24,13 @@ export class ClientCreationData {
         return undefined;
       case "lightclient":
         // can only make a lightclient into a config if it is a preset (fetchable from github).
-        if (this.#inner.is_preset) {
+        if (this.#inner.chain_spec instanceof File) {
+          return undefined;
+        } else {
           return new ClientCreationConfig({
             tag: "lightclient",
             chain_name: this.#inner.chain_spec.name,
           });
-        } else {
-          return undefined;
         }
     }
   }
@@ -55,6 +55,5 @@ export type OfflineClientCreationData = {
 
 export type LightClientCreationData = {
   tag: "lightclient";
-  is_preset: boolean;
-  chain_spec: ChainSpec;
+  chain_spec: ChainSpec | File;
 };

--- a/src/state/models/client_creation_data.ts
+++ b/src/state/models/client_creation_data.ts
@@ -1,0 +1,60 @@
+import { ChainSpec } from "../../services/chain_spec_service";
+import { ClientCreationConfig } from "./client_creation_config";
+
+export class ClientCreationData {
+  #inner: TClientCreationData;
+
+  get deref(): TClientCreationData {
+    return this.#inner;
+  }
+
+  constructor(inner: TClientCreationData) {
+    this.#inner = inner;
+  }
+
+  tryIntoConfig(): ClientCreationConfig | undefined {
+    switch (this.#inner.tag) {
+      case "url":
+        return new ClientCreationConfig({
+          tag: "url",
+          url: this.#inner.url,
+        });
+      case "file":
+        // cannot make a file into a config, because configs need to be sharaeble via query params.
+        return undefined;
+      case "lightclient":
+        // can only make a lightclient into a config if it is a preset (fetchable from github).
+        if (this.#inner.is_preset) {
+          return new ClientCreationConfig({
+            tag: "lightclient",
+            chain_name: this.#inner.chain_spec.name,
+          });
+        } else {
+          return undefined;
+        }
+    }
+  }
+}
+
+export type ClientCreationDataTag = TClientCreationData["tag"];
+
+type TClientCreationData =
+  | OnlineClientCreationData
+  | OfflineClientCreationData
+  | LightClientCreationData;
+
+export type OnlineClientCreationData = {
+  tag: "url";
+  url: string;
+};
+
+export type OfflineClientCreationData = {
+  tag: "file";
+  file: File;
+};
+
+export type LightClientCreationData = {
+  tag: "lightclient";
+  is_preset: boolean;
+  chain_spec: ChainSpec;
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -22,3 +22,7 @@ export async function readFileAsBytes(file: File): Promise<Uint8Array> {
 }
 
 export const wait = (ms: number) => new Promise((res) => setTimeout(res, ms));
+
+export function paramsToString(params: Record<string, string>): string {
+  return new URLSearchParams(Object.entries(params)).toString();
+}


### PR DESCRIPTION
Users can now use their own `chain_spec.json` files to connect via the Smoldot lightclient integration that subxt can use under the `unstable-lightclient` feature flag.
Also at the start of the web app, chain spec presets are fetched from [This Repo](https://github.com/paritytech/substrate-connect/tree/main/packages/connect/src/connector/specs) via the github API. Currently this amounts to 4 chain specs. They are loaded in about 100ms, so it is not that bad. Users can select these presets instead of supplying their own chain specs:
![image](https://github.com/paritytech/subxt-explorer/assets/62739623/e74b9702-fef6-4b1f-ad13-bd4eae408c40)

Also the app state has been cleaned up a little. Creating a client now involves two data structures, a `ClientCreationConfig` and `ClientCreationData`. 
At any point of the app lifecycle, a `ClientCreationConfig` can be derived from the query params. This is also done at app start. Any `ClientCreationConfig` can be used to generate `ClientCreationData`, which then is passed to the Rust Code in WASM to initiate the connection. 
However the opposite way (`ClientCreationData` -> `ClientCreationConfig`) is not always possible. That is because a `ClientCreationConfig` should be 100% representable in terms of query params. Which is e.g. not possible if a user uploads a file. 

There is now the option to share URLs that use light client presets. For this a url needs to contain `?lightclient=Polkadot`. This creates a `ClientCreationConfig` at app starts that is checked against any chain specs obtained from the aforementioned [substrate connect repo](https://github.com/paritytech/substrate-connect/tree/main/packages/connect/src/connector/specs). 

Currently connecting with a light client is super slow. Ofter 30+ seconds. I think it is due to some state synching smoldot is doing. Also Smoldot makes a lot of P2P requests to random IP addresses that sometimes fail (sometimes a lot), which currently clutters the Javascript Console with error messages.
