### PR TITLE
Show a big loading indicator on page load to not confuse users.

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -69,7 +69,7 @@ const AppInRouter: Component = () => {
       AppConfig.instance.updateWith(configFromParams);
       if (pathname === "/" || pathname === "") {
         // if already on homepage adjust its UI to the new config:
-        HomePageState.instance.setupUiToMatchAppConfig();
+        HomePageState.instance.reconfigureUiForNewAppConfig();
       } else {
         // otherwise navigate to homepage and set redirect hook:
         const redirectUrl = `/?${AppConfig.instance.toParamsString()}`;

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -90,7 +90,7 @@ function clientConnectionSpan(
     case "url":
       return (
         <span>
-          {"Connected to: "}
+          {"Connected via RPC: "}
           <span class="text-pink-500">{clientCreationData.deref.url}</span>
         </span>
       );
@@ -104,7 +104,12 @@ function clientConnectionSpan(
         </span>
       );
     case "lightclient":
-      return <span>{"Connected to LightClient"}</span>;
+      {
+        ("Connected via Light Client: ");
+      }
+      <span class="text-pink-500">
+        {clientCreationData.deref.chain_spec.name}
+      </span>;
   }
 }
 

--- a/src/state/app_config.ts
+++ b/src/state/app_config.ts
@@ -13,6 +13,8 @@ export class AppConfig {
   #setAppConfigParamString: Setter<string>;
   appConfigParamString: Accessor<string>;
 
+  clientCreationConfigSignal: Accessor<ClientCreationConfig | undefined>;
+  #setClientCreationConfigSignal: Setter<ClientCreationConfig | undefined>;
   static #instance: AppConfig;
   static get instance(): AppConfig {
     if (AppConfig.#instance === undefined) {
@@ -25,6 +27,7 @@ export class AppConfig {
     this.clientCreationConfig = clientCreationConfig;
     const paramsString = this.toParamsString();
     this.#setAppConfigParamString(paramsString);
+    this.#setClientCreationConfigSignal(clientCreationConfig);
   }
 
   constructor(clientCreationConfig: ClientCreationConfig | undefined) {
@@ -33,6 +36,11 @@ export class AppConfig {
       createSignal<string>(this.toParamsString());
     this.appConfigParamString = appConfigParamString;
     this.#setAppConfigParamString = setAppConfigParamString;
+
+    const [clientCreationConfigSignal, setClientCreationConfigSignal] =
+      createSignal<ClientCreationConfig | undefined>(this.clientCreationConfig);
+    this.clientCreationConfigSignal = clientCreationConfigSignal;
+    this.#setClientCreationConfigSignal = setClientCreationConfigSignal;
   }
 
   /// Returns a signal that contains an href to a local path with the current app config as a query string.

--- a/src/state/models/client_creation_config.ts
+++ b/src/state/models/client_creation_config.ts
@@ -103,12 +103,12 @@ export type TClientCreationConfig =
   | OnlineClientCreationConfig
   | LightClientCreationConfig;
 
-type OnlineClientCreationConfig = {
+export type OnlineClientCreationConfig = {
   tag: "url";
   url: string;
 };
 
-type LightClientCreationConfig = {
+export type LightClientCreationConfig = {
   tag: "lightclient";
   chain_name: string;
 };


### PR DESCRIPTION
There are now 3 loading states that the home page can be in:
- `undefined` = idle: Show the Tab layout for connection options + the "Generate" Button.
- `"page-load"` = connecting to a client on page load: Show just a big loading indicator
- `"ui-interaction-load"` = connecting to a client as a result of some user actions (typing a url, selecting a lightclient): Show the Tab layout for connection options + the big loading indicator.

For the light client a warning is included that it might take longer to connect.

![image](https://github.com/paritytech/subxt-explorer/assets/62739623/35a36025-14d9-4c6f-a104-bf5f1e4470e6)


![image](https://github.com/paritytech/subxt-explorer/assets/62739623/41a759ad-a03c-432a-936c-7e4039477a46)
